### PR TITLE
Autofill date added and show eight recent recipes

### DIFF
--- a/functions/_shared/recipe.js
+++ b/functions/_shared/recipe.js
@@ -21,7 +21,9 @@ export function buildRecipe(input, options = {}) {
   const cooktime = normalizeDuration(input.cooktime || input.cookTime);
   const totaltime = normalizeDuration(input.totaltime || input.totalTime);
   const difficulty = normalizeDifficulty(input.difficulty);
-  const date_added = normalizeDate(input.date_added || input.dateAdded);
+  const submittedDate = input.date_added || input.dateAdded;
+  const normalizedDate = normalizeDate(submittedDate);
+  const date_added = normalizedDate || todayDate();
   const status = normalizeStatus(input.status);
   const reviewed = Boolean(input.reviewed);
   const notes = cleanText(input.notes, 600);
@@ -39,7 +41,7 @@ export function buildRecipe(input, options = {}) {
   if (!totaltime) warnings.push("Total time is missing or not an ISO-8601 duration like PT1H5M.");
   if (input.difficulty && !difficulty) warnings.push("Difficulty must be Easy, Medium, or Hard.");
   if (input.status && !status) warnings.push("Status must be published, planned, or draft.");
-  if (input.date_added && !date_added) warnings.push("Date added must use YYYY-MM-DD format.");
+  if (submittedDate && !normalizedDate) warnings.push("Date added must use YYYY-MM-DD format. Using today's date instead.");
   if (!categories.length) warnings.push("Categories are missing.");
   if (!tags.length) warnings.push("Tags are missing.");
   if (!image) warnings.push("No image provided.");
@@ -196,6 +198,10 @@ function normalizeStatus(value) {
 function normalizeDate(value) {
   const date = cleanText(value, 20);
   return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : "";
+}
+
+function todayDate() {
+  return new Date().toISOString().slice(0, 10);
 }
 
 function normalizeUnitsAndFractions(value) {

--- a/pages/index.md
+++ b/pages/index.md
@@ -32,7 +32,7 @@ permalink: /
     <div class="recipes xs-px1 recipe-grid">
       {% assign published_recipes = site.recipes | where_exp: "item", "item.status != 'draft' and item.status != 'planned'" %}
       {% assign dated_recipes = published_recipes | where_exp: "item", "item.date_added" | sort: "date_added" | reverse %}
-      {% for post in dated_recipes limit:6 %}
+      {% for post in dated_recipes limit:8 %}
         <a class="block relative recipe-tile {% if post.image %}has-image{% else %}no-image{% endif %}" href="{{ post.url }}" {% if post.image %}data-image-url="{% if post.image and post.image contains 'http' %}{{ post.image | escape }}{% else %}{{ '/images/' | append: post.image | relative_url | escape }}{% endif %}"{% endif %}>
           <div class="image ratio bg-cover"
               {% if post.image and post.image contains 'http' %}
@@ -64,67 +64,67 @@ SimpleJekyllSearch({
 </script>
 
 <script>
-	var activeTagFilter = 'all';
+ 	var activeTagFilter = 'all';
 
-	function normalizeTagText(value) {
-		return (value || '').toString().toLowerCase().trim();
-	}
+ 	function normalizeTagText(value) {
+ 		return (value || '').toString().toLowerCase().trim();
+ 	}
 
-	function applyTagFilter() {
-		var cards = document.querySelectorAll('#results-container .result-card');
-		for (var i = 0; i < cards.length; i++) {
-			var card = cards[i];
-			var tagBlob = normalizeTagText(card.getAttribute('data-tags'));
-			if (activeTagFilter === 'all') {
-				card.style.display = '';
-			} else if (tagBlob.indexOf(activeTagFilter) !== -1) {
-				card.style.display = '';
-			} else {
-				card.style.display = 'none';
-			}
-		}
-	}
+ 	function applyTagFilter() {
+ 		var cards = document.querySelectorAll('#results-container .result-card');
+ 		for (var i = 0; i < cards.length; i++) {
+ 			var card = cards[i];
+ 			var tagBlob = normalizeTagText(card.getAttribute('data-tags'));
+ 			if (activeTagFilter === 'all') {
+ 				card.style.display = '';
+ 			} else if (tagBlob.indexOf(activeTagFilter) !== -1) {
+ 				card.style.display = '';
+ 			} else {
+ 				card.style.display = 'none';
+ 			}
+ 		}
+ 	}
 
   function setActiveChip(chip) {
-		var chips = document.querySelectorAll('.tag-filter');
-		for (var i = 0; i < chips.length; i++) {
-			chips[i].classList.remove('is-active', 'btn-primary');
-			chips[i].classList.add('btn-outline-primary');
-		}
-		chip.classList.add('is-active', 'btn-primary');
-		chip.classList.remove('btn-outline-primary');
-	}
+ 		var chips = document.querySelectorAll('.tag-filter');
+ 		for (var i = 0; i < chips.length; i++) {
+ 			chips[i].classList.remove('is-active', 'btn-primary');
+ 			chips[i].classList.add('btn-outline-primary');
+ 		}
+ 		chip.classList.add('is-active', 'btn-primary');
+ 		chip.classList.remove('btn-outline-primary');
+ 	}
 
-	function updateHomepageSections() {
-		var query = ($('#search-input').val() || '').toString().trim();
-		var recentSection = document.getElementById('recently-added-section');
-		var resultsWrap = document.getElementById('search-results-wrap');
+ 	function updateHomepageSections() {
+ 		var query = ($('#search-input').val() || '').toString().trim();
+ 		var recentSection = document.getElementById('recently-added-section');
+ 		var resultsWrap = document.getElementById('search-results-wrap');
 
-		if (!recentSection || !resultsWrap) return;
+ 		if (!recentSection || !resultsWrap) return;
 
-		if (query.length > 0) {
-			recentSection.classList.add('is-hidden');
-			resultsWrap.classList.remove('is-hidden');
-		} else {
-			recentSection.classList.remove('is-hidden');
-			resultsWrap.classList.add('is-hidden');
-		}
-	}
+ 		if (query.length > 0) {
+ 			recentSection.classList.add('is-hidden');
+ 			resultsWrap.classList.remove('is-hidden');
+ 		} else {
+ 			recentSection.classList.remove('is-hidden');
+ 			resultsWrap.classList.add('is-hidden');
+ 		}
+ 	}
 
-	$( document ).ready(function() {
-		$('.tag-filter').on('click', function() {
-			activeTagFilter = normalizeTagText($(this).data('tag'));
-			setActiveChip(this);
-			setTimeout(applyTagFilter, 50);
-		});
+ 	$( document ).ready(function() {
+ 		$('.tag-filter').on('click', function() {
+ 			activeTagFilter = normalizeTagText($(this).data('tag'));
+ 			setActiveChip(this);
+ 			setTimeout(applyTagFilter, 50);
+ 		});
 
     $('#search-input').on('input', function() {
-			updateHomepageSections();
-			setTimeout(applyTagFilter, 50);
-		});
+ 			updateHomepageSections();
+ 			setTimeout(applyTagFilter, 50);
+ 		});
 
-		updateHomepageSections();
-		setTimeout(applyTagFilter, 150);
-	});
-	
+ 		updateHomepageSections();
+ 		setTimeout(applyTagFilter, 150);
+ 	});
+ 	
 </script>

--- a/submit-recipe.html
+++ b/submit-recipe.html
@@ -115,7 +115,7 @@ permalink: /submit-recipe.html
   const previewCode = document.getElementById("recipe-preview-code");
   const timeSummary = document.getElementById("recipe-time-summary");
 
-  form.elements.date_added.value = new Date().toISOString().slice(0, 10);
+  setDateAddedIfBlank();
   updateTimeSummary();
 
   ["prep_hours", "prep_minutes", "cook_hours", "cook_minutes"].forEach((name) => {
@@ -162,7 +162,7 @@ permalink: /submit-recipe.html
       preptime: prep,
       cooktime: cook,
       totaltime: total,
-      date_added: data.get("date_added"),
+      date_added: data.get("date_added") || todayDate(),
       status: data.get("status"),
       reviewed: data.get("reviewed") === "on",
       difficulty: data.get("difficulty"),
@@ -254,12 +254,27 @@ permalink: /submit-recipe.html
 
   function clearForm() {
     form.reset();
-    form.elements.date_added.value = new Date().toISOString().slice(0, 10);
+    setDateAddedIfBlank();
     updateTimeSummary();
     preview.hidden = true;
     previewCode.textContent = "";
     previewCode.dataset.markdown = "";
     statusBox.textContent = "";
+  }
+
+  function todayDate() {
+    const today = new Date();
+    return [today.getFullYear(), padDatePart(today.getMonth() + 1), padDatePart(today.getDate())].join("-");
+  }
+
+  function padDatePart(value) {
+    return String(value).padStart(2, "0");
+  }
+
+  function setDateAddedIfBlank() {
+    if (!form.elements.date_added.value) {
+      form.elements.date_added.value = todayDate();
+    }
   }
 
   function highlightYaml(markdown) {


### PR DESCRIPTION
## Summary
- Change the home page Recently Added loop from 6 to 8 recipes.
- Autofill Submit a Recipe `Date Added` with today.
- Include today when the submit payload has no `date_added` value.
- Add a Pages Functions fallback so generated recipe Markdown still gets `date_added` when the field is blank.

## Why
Recently Added only showed 6 recipes because `pages/index.md` used `limit:6` in the Liquid loop.

## Testing
Not run locally in this environment.