### PR TITLE
Add recipe version history

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,8 @@ lang_direction: "ltr"
 color: "#007FFF"
 twitter_username: 
 github_username:  cjthedj97
+github_repository: cjthedj97/chowdown
+github_branch: main
 
 # Build settings
 markdown: kramdown

--- a/_includes/recipe-history.html
+++ b/_includes/recipe-history.html
@@ -1,0 +1,20 @@
+{% if site.github_repository %}
+  {% assign recipe_history_branch = site.github_branch | default: "main" %}
+  {% assign recipe_history_url = "https://github.com/" | append: site.github_repository | append: "/commits/" | append: recipe_history_branch | append: "/" | append: page.path %}
+  <section
+    id="recipe-history-panel"
+    class="recipe-history-panel mt2 px2 py2 is-hidden"
+    data-repo="{{ site.github_repository | escape }}"
+    data-branch="{{ recipe_history_branch | escape }}"
+    data-path="{{ page.path | escape }}"
+    data-history-url="{{ recipe_history_url | escape }}"
+    data-limit="5"
+    hidden>
+    <div class="recipe-history-heading">
+      <h2 class="m0">Recipe History</h2>
+      <a id="recipe-history-github" href="{{ recipe_history_url | escape }}" target="_blank" rel="noopener">View full history on GitHub</a>
+    </div>
+    <p id="recipe-history-status" class="recipe-history-status">Loading history from GitHub…</p>
+    <ol id="recipe-history-list" class="recipe-history-list"></ol>
+  </section>
+{% endif %}

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -35,9 +35,13 @@ layout: recipe_default
       <button id="favorite-toggle" class="btn btn-sm btn-outline-primary" type="button">Save Favorite</button>
       <button id="print-recipe" class="btn btn-sm btn-outline-secondary" type="button">Print Recipe</button>
       <button id="recipe-timer-open" class="btn btn-sm btn-outline-secondary" type="button">Timer</button>
+      {% if site.github_repository %}
+        <button id="recipe-history-toggle" class="btn btn-sm btn-outline-secondary" type="button" aria-expanded="false" aria-controls="recipe-history-panel">View History</button>
+      {% endif %}
       <button id="share-recipe" class="btn btn-sm btn-outline-secondary d-inline-block d-md-none" type="button">Share Link</button>
       <button id="copy-link" class="btn btn-sm btn-outline-secondary d-none d-md-inline-block" type="button">Copy Link</button>
     </div>
+    {% include recipe-history.html %}
     {% include yield.html recipe=page %}
     {% include timings.html recipe=page %}
     {% if page.notes %}
@@ -246,11 +250,19 @@ layout: recipe_default
   {% endfor %}
 ]</script>
 <script src="{{ "/js/recipe-timer.js" | relative_url }}" type="text/javascript"></script>
+<script src="{{ "/js/recipe-history.js" | relative_url }}" type="text/javascript"></script>
 <script>
   window.ChowdownFavorites.initRecipeFavoriteButton({
     buttonId: 'favorite-toggle',
     recipeUrl: '{{page.url}}'
   });
+
+  if (window.ChowdownRecipeHistory) {
+    window.ChowdownRecipeHistory.init({
+      buttonId: 'recipe-history-toggle',
+      panelId: 'recipe-history-panel'
+    });
+  }
 
   (function () {
     var printButton = document.getElementById('print-recipe');

--- a/js/recipe-history.js
+++ b/js/recipe-history.js
@@ -1,0 +1,131 @@
+(function (window, document) {
+  function init(options) {
+    var button = document.getElementById(options.buttonId);
+    var panel = document.getElementById(options.panelId);
+
+    if (!button || !panel) return;
+
+    var loaded = false;
+    var repo = panel.getAttribute('data-repo') || '';
+    var branch = panel.getAttribute('data-branch') || 'main';
+    var path = panel.getAttribute('data-path') || '';
+    var historyUrl = panel.getAttribute('data-history-url') || '';
+    var limit = Number(panel.getAttribute('data-limit') || 5);
+    var status = document.getElementById('recipe-history-status');
+    var list = document.getElementById('recipe-history-list');
+    var githubLink = document.getElementById('recipe-history-github');
+
+    if (githubLink && historyUrl) {
+      githubLink.href = historyUrl;
+    }
+
+    button.addEventListener('click', function () {
+      var isHidden = panel.hidden || panel.classList.contains('is-hidden');
+      setPanelVisible(isHidden);
+
+      if (isHidden && !loaded) {
+        loaded = true;
+        loadHistory();
+      }
+    });
+
+    function setPanelVisible(visible) {
+      panel.hidden = !visible;
+      panel.classList.toggle('is-hidden', !visible);
+      button.setAttribute('aria-expanded', visible ? 'true' : 'false');
+    }
+
+    function loadHistory() {
+      if (!repo || !path || !window.fetch) {
+        showFallback('History is available on GitHub.');
+        return;
+      }
+
+      if (status) status.textContent = 'Loading history from GitHub…';
+
+      var endpoint = 'https://api.github.com/repos/' + repo + '/commits'
+        + '?sha=' + encodeURIComponent(branch)
+        + '&path=' + encodeURIComponent(path)
+        + '&per_page=' + encodeURIComponent(limit);
+
+      window.fetch(endpoint, { headers: { accept: 'application/vnd.github+json' } })
+        .then(function (response) {
+          if (!response.ok) throw new Error('History request failed');
+          return response.json();
+        })
+        .then(function (commits) {
+          renderHistory(Array.isArray(commits) ? commits : []);
+        })
+        .catch(function () {
+          showFallback('Could not load history here. Use the GitHub link for full recipe history.');
+        });
+    }
+
+    function renderHistory(commits) {
+      if (!list) return;
+
+      list.innerHTML = '';
+
+      if (!commits.length) {
+        showFallback('No recipe history entries were returned by GitHub.');
+        return;
+      }
+
+      commits.forEach(function (entry) {
+        var commit = entry.commit || {};
+        var authorInfo = commit.author || commit.committer || {};
+        var author = getAuthorName(entry, authorInfo);
+        var message = firstLine(commit.message) || 'Recipe update';
+        var date = formatDate(authorInfo.date);
+        var url = entry.html_url || historyUrl;
+
+        var item = document.createElement('li');
+        var title = document.createElement('a');
+        var meta = document.createElement('span');
+
+        title.className = 'recipe-history-entry-title';
+        title.href = url;
+        title.target = '_blank';
+        title.rel = 'noopener';
+        title.textContent = message;
+
+        meta.className = 'recipe-history-entry-meta';
+        meta.textContent = [date, author].filter(Boolean).join(' · ');
+
+        item.appendChild(title);
+        item.appendChild(meta);
+        list.appendChild(item);
+      });
+
+      if (status) status.textContent = 'Latest recipe updates from GitHub.';
+    }
+
+    function showFallback(message) {
+      if (status) status.textContent = message;
+      if (list) list.innerHTML = '';
+    }
+  }
+
+  function getAuthorName(entry, authorInfo) {
+    if (entry.author && entry.author.login) return entry.author.login;
+    if (authorInfo && authorInfo.name) return authorInfo.name;
+    return 'Unknown author';
+  }
+
+  function firstLine(message) {
+    return String(message || '').split('\n')[0].trim();
+  }
+
+  function formatDate(value) {
+    if (!value) return '';
+    var date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  window.ChowdownRecipeHistory = { init: init };
+})(window, document);


### PR DESCRIPTION
Adds a View History action on recipe pages with GitHub-backed entries and a direct link to the file history.

Testing: not run locally.

Related: #73