### PR TITLE
Add recipe validation report

### DIFF
--- a/functions/_shared/github-validation.js
+++ b/functions/_shared/github-validation.js
@@ -1,0 +1,56 @@
+const DEFAULT_BASE_BRANCH = "main";
+
+export async function checkRecipeFileExists(recipe, env) {
+  const owner = env.GITHUB_OWNER || "cjthedj97";
+  const repo = env.GITHUB_REPO || "chowdown";
+  const base = env.GITHUB_BASE_BRANCH || DEFAULT_BASE_BRANCH;
+  const token = env.GITHUB_TOKEN;
+  const path = `/repos/${owner}/${repo}/contents/${encodeURIComponentPath(recipe.path)}?ref=${encodeURIComponent(base)}`;
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: buildHeaders(token)
+  });
+
+  if (response.status === 404) {
+    return {
+      checked: true,
+      exists: false,
+      path: recipe.path,
+      branch: base
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      checked: false,
+      exists: false,
+      path: recipe.path,
+      branch: base,
+      error: `GitHub duplicate check failed with status ${response.status}.`
+    };
+  }
+
+  return {
+    checked: true,
+    exists: true,
+    path: recipe.path,
+    branch: base
+  };
+}
+
+function buildHeaders(token) {
+  const headers = {
+    "accept": "application/vnd.github+json",
+    "user-agent": "recipe-validation-pages-function",
+    "x-github-api-version": "2022-11-28"
+  };
+
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+function encodeURIComponentPath(path) {
+  return path.split("/").map(encodeURIComponent).join("/");
+}

--- a/functions/_shared/github.js
+++ b/functions/_shared/github.js
@@ -11,8 +11,17 @@ export async function createRecipePullRequest(recipe, warnings, env) {
     throw new Error("GITHUB_TOKEN is not configured.");
   }
 
-  const branch = `${BRANCH_PREFIX}/${recipe.slug}-${Date.now()}`;
   const repoPath = `/repos/${owner}/${repo}`;
+  const existing = await github(`${repoPath}/contents/${encodeURIComponentPath(recipe.path)}?ref=${encodeURIComponent(base)}`, {
+    token,
+    allow404: true
+  });
+
+  if (existing && !existing.notFound) {
+    throw new Error(`A recipe already exists at ${recipe.path}.`);
+  }
+
+  const branch = `${BRANCH_PREFIX}/${recipe.slug}-${Date.now()}`;
   const baseRef = await github(`${repoPath}/git/ref/heads/${base}`, { token });
   const baseSha = baseRef.object.sha;
 
@@ -24,15 +33,6 @@ export async function createRecipePullRequest(recipe, warnings, env) {
       sha: baseSha
     }
   });
-
-  const existing = await github(`${repoPath}/contents/${encodeURIComponentPath(recipe.path)}?ref=${encodeURIComponent(base)}`, {
-    token,
-    allow404: true
-  });
-
-  if (existing && !existing.notFound) {
-    throw new Error(`A recipe already exists at ${recipe.path}.`);
-  }
 
   await github(`${repoPath}/contents/${encodeURIComponentPath(recipe.path)}`, {
     token,

--- a/functions/_shared/recipe.js
+++ b/functions/_shared/recipe.js
@@ -6,13 +6,18 @@ const ALLOWED_STATUSES = new Set(["published", "planned", "draft"]);
 export function buildRecipe(input, options = {}) {
   const errors = [];
   const warnings = [];
+  const validation_report = createValidationReport();
 
   if (input.website || input.company || input.url) {
-    errors.push("Spam check failed.");
+    addValidationCheck(validation_report, errors, warnings, "error", "spam_check", "spam_check_failed", "Spam check failed.");
+  } else {
+    addValidationCheck(validation_report, errors, warnings, "pass", "spam_check", "spam_check_passed", "Spam check passed.");
   }
 
   if (options.verifyTurnstile && !input.turnstileToken) {
-    errors.push("Turnstile token is required.");
+    addValidationCheck(validation_report, errors, warnings, "error", "turnstile", "turnstile_required", "Turnstile token is required.");
+  } else if (options.verifyTurnstile) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "turnstile", "turnstile_present", "Turnstile token is present.");
   }
 
   const title = cleanText(input.title, 120);
@@ -34,23 +39,72 @@ export function buildRecipe(input, options = {}) {
   const ingredients = cleanGroups(input.ingredients, 12, 50, 180);
   const directions = cleanGroups(input.directions, 12, 60, 320);
 
-  if (!title) errors.push("Title is required.");
-  if (!yieldValue) warnings.push("Yield is missing.");
-  if (!preptime) warnings.push("Prep time is missing or not an ISO-8601 duration like PT20M.");
-  if (!cooktime) warnings.push("Cook time is missing or not an ISO-8601 duration like PT45M.");
-  if (!totaltime) warnings.push("Total time is missing or not an ISO-8601 duration like PT1H5M.");
-  if (input.difficulty && !difficulty) warnings.push("Difficulty must be Easy, Medium, or Hard.");
-  if (input.status && !status) warnings.push("Status must be published, planned, or draft.");
-  if (submittedDate && !normalizedDate) warnings.push("Date added must use YYYY-MM-DD format. Using today's date instead.");
-  if (!categories.length) warnings.push("Categories are missing.");
-  if (!tags.length) warnings.push("Tags are missing.");
-  if (!image) warnings.push("No image provided.");
-  if (image && !imagecredit) warnings.push("Image provided without image credit.");
-  if (!ingredients.length) errors.push("At least one ingredient is required.");
-  if (!directions.length) errors.push("At least one direction is required.");
+  if (title) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "title", "title_present", "Title is present.");
+  } else {
+    addValidationCheck(validation_report, errors, warnings, "error", "title", "title_required", "Title is required.");
+  }
+
+  if (yieldValue) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "yield", "yield_present", "Yield is present.");
+  } else {
+    addValidationCheck(validation_report, errors, warnings, "warning", "yield", "yield_missing", "Yield is missing.");
+  }
+
+  validateDuration(validation_report, errors, warnings, "preptime", input.preptime || input.prepTime, preptime, "Prep time is missing or not an ISO-8601 duration like PT20M.");
+  validateDuration(validation_report, errors, warnings, "cooktime", input.cooktime || input.cookTime, cooktime, "Cook time is missing or not an ISO-8601 duration like PT45M.");
+  validateDuration(validation_report, errors, warnings, "totaltime", input.totaltime || input.totalTime, totaltime, "Total time is missing or not an ISO-8601 duration like PT1H5M.");
+
+  if (input.difficulty && !difficulty) {
+    addValidationCheck(validation_report, errors, warnings, "warning", "difficulty", "difficulty_invalid", "Difficulty must be Easy, Medium, or Hard.");
+  } else if (difficulty) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "difficulty", "difficulty_valid", "Difficulty is valid.");
+  }
+
+  if (input.status && !status) {
+    addValidationCheck(validation_report, errors, warnings, "warning", "status", "status_invalid", "Status must be published, planned, or draft.");
+  } else if (status) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "status", "status_valid", "Status is valid.");
+  }
+
+  if (submittedDate && !normalizedDate) {
+    addValidationCheck(validation_report, errors, warnings, "warning", "date_added", "date_added_invalid", "Date added must use YYYY-MM-DD format. Using today's date instead.");
+  } else if (date_added) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "date_added", "date_added_valid", "Date added is valid.");
+  }
+
+  if (categories.length) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "categories", "categories_present", "Categories are present.");
+  } else {
+    addValidationCheck(validation_report, errors, warnings, "warning", "categories", "categories_missing", "Categories are missing.");
+  }
+
+  if (tags.length) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "tags", "tags_present", "Tags are present.");
+  } else {
+    addValidationCheck(validation_report, errors, warnings, "warning", "tags", "tags_missing", "Tags are missing.");
+  }
+
+  if (!image) {
+    addValidationCheck(validation_report, errors, warnings, "warning", "image", "image_missing", "No image provided.");
+  } else if (!imagecredit) {
+    addValidationCheck(validation_report, errors, warnings, "warning", "imagecredit", "image_credit_missing", "Image provided without image credit.");
+  } else {
+    addValidationCheck(validation_report, errors, warnings, "pass", "image", "image_and_credit_present", "Image and image credit are present.");
+  }
+
+  validateGroups(validation_report, errors, warnings, "ingredients", input.ingredients, ingredients, "At least one ingredient is required.");
+  validateGroups(validation_report, errors, warnings, "directions", input.directions, directions, "At least one direction is required.");
 
   const slug = slugify(title);
-  if (!slug) errors.push("Title must produce a valid filename slug.");
+  if (slug) {
+    addValidationCheck(validation_report, errors, warnings, "pass", "slug", "slug_valid", `Recipe filename will be ${RECIPE_DIR}/${slug}.md.`);
+  } else {
+    addValidationCheck(validation_report, errors, warnings, "error", "slug", "slug_invalid", "Title must produce a valid filename slug.");
+  }
+
+  addValidationCheck(validation_report, errors, warnings, "pass", "layout", "layout_valid", "Generated layout field is valid.");
+  addValidationCheck(validation_report, errors, warnings, "pass", "recipe_schema", "recipe_schema_valid", `Generated recipe_schema is ${RECIPE_SCHEMA_VERSION}.`);
 
   const recipeData = {
     layout: "recipe",
@@ -74,11 +128,13 @@ export function buildRecipe(input, options = {}) {
   };
 
   const markdown = formatRecipeMarkdown(recipeData);
+  finalizeValidationReport(validation_report);
 
   return {
     ok: errors.length === 0,
     errors,
     warnings,
+    validation_report,
     recipe: {
       title,
       slug,
@@ -87,6 +143,27 @@ export function buildRecipe(input, options = {}) {
     },
     preview: markdown
   };
+}
+
+export function addValidationCheck(report, errors, warnings, status, field, code, message) {
+  const check = { status, field, code, message };
+  report.checks.push(check);
+
+  if (status === "error") errors.push(message);
+  if (status === "warning") warnings.push(message);
+
+  return check;
+}
+
+export function finalizeValidationReport(report) {
+  report.ok = !report.checks.some((check) => check.status === "error");
+  report.summary = report.checks.reduce((summary, check) => {
+    if (check.status === "error") summary.errors += 1;
+    if (check.status === "warning") summary.warnings += 1;
+    if (check.status === "pass") summary.passes += 1;
+    return summary;
+  }, { errors: 0, warnings: 0, passes: 0 });
+  return report;
 }
 
 export function formatRecipeMarkdown(recipe) {
@@ -124,6 +201,37 @@ export function formatRecipeMarkdown(recipe) {
   lines.push("---");
 
   return `${lines.join("\n")}\n`;
+}
+
+function createValidationReport() {
+  return {
+    ok: false,
+    summary: { errors: 0, warnings: 0, passes: 0 },
+    checks: []
+  };
+}
+
+function validateDuration(report, errors, warnings, field, rawValue, normalizedValue, message) {
+  if (normalizedValue) {
+    addValidationCheck(report, errors, warnings, "pass", field, `${field}_valid`, `${field} is a valid ISO-8601 duration.`);
+    return;
+  }
+
+  addValidationCheck(report, errors, warnings, "warning", field, `${field}_missing_or_invalid`, message);
+}
+
+function validateGroups(report, errors, warnings, field, rawGroups, groups, requiredMessage) {
+  if (!groups.length) {
+    addValidationCheck(report, errors, warnings, "error", field, `${field}_required`, requiredMessage);
+    return;
+  }
+
+  if (hasEmptyGroups(rawGroups)) {
+    addValidationCheck(report, errors, warnings, "error", field, `${field}_empty_group`, `${field} cannot include empty groups.`);
+    return;
+  }
+
+  addValidationCheck(report, errors, warnings, "pass", field, `${field}_valid`, `${field} are present and groups are non-empty.`);
 }
 
 function appendOptionalString(lines, key, value) {
@@ -170,12 +278,21 @@ function cleanGroups(value, maxGroups, maxItems, maxLength) {
 
     if (entry && typeof entry === "object") {
       const name = cleanText(entry.name, 60);
-      const items = cleanList(entry.items, maxItems, maxLength).map(normalizeUnitsAndFractions);
+      const items = cleanList(entry.items, maxItems, maxLength).map(normalizeUnitsAndFractions).filter(Boolean);
       if (items.length) groups.push({ name, items });
     }
   }
 
   return groups;
+}
+
+function hasEmptyGroups(value) {
+  if (!Array.isArray(value)) return false;
+
+  return value.some((entry) => {
+    if (!entry || typeof entry !== "object" || typeof entry === "string") return false;
+    return Array.isArray(entry.items) && entry.items.length === 0;
+  });
 }
 
 function normalizeDuration(value) {

--- a/functions/api/recipes/edit.js
+++ b/functions/api/recipes/edit.js
@@ -13,12 +13,12 @@ export async function onRequestPost({ request, env }) {
     const validation = buildRecipe(submission, { verifyTurnstile: true });
 
     if (!validation.ok) {
-      return json({ ok: false, errors: validation.errors, warnings: validation.warnings }, 400);
+      return json({ ok: false, errors: validation.errors, warnings: validation.warnings, validation_report: validation.validation_report }, 400);
     }
 
     const turnstile = await verifyTurnstile(submission.turnstileToken, request, env);
     if (!turnstile.ok) {
-      return json({ ok: false, errors: [turnstile.error || "Turnstile verification failed."], warnings: validation.warnings }, 403);
+      return json({ ok: false, errors: [turnstile.error || "Turnstile verification failed."], warnings: validation.warnings, validation_report: validation.validation_report }, 403);
     }
 
     const editRequest = {
@@ -26,7 +26,7 @@ export async function onRequestPost({ request, env }) {
       original_title: submission.original_title
     };
     const pr = await createRecipeEditPullRequest(validation.recipe, validation.warnings, env, editRequest);
-    return json({ ok: true, pullRequest: pr, warnings: validation.warnings }, 201);
+    return json({ ok: true, pullRequest: pr, warnings: validation.warnings, validation_report: validation.validation_report }, 201);
   } catch (error) {
     return json({ ok: false, error: error.message || "Unexpected error" }, 500);
   }

--- a/functions/api/recipes/preview.js
+++ b/functions/api/recipes/preview.js
@@ -11,7 +11,9 @@ export async function onRequestPost({ request, env }) {
     const submission = await readSubmission(request);
     const result = buildRecipe(submission, { verifyTurnstile: false });
 
-    if (result.recipe && result.recipe.path && result.recipe.slug) {
+    if (isEditSubmission(submission)) {
+      addEditPathCheck(result, submission);
+    } else if (result.recipe && result.recipe.path && result.recipe.slug) {
       await addDuplicatePathCheck(result, env);
     }
 
@@ -27,6 +29,17 @@ export async function onRequestPost({ request, env }) {
 
 export async function onRequest() {
   return methodNotAllowed();
+}
+
+function isEditSubmission(submission) {
+  return submission.mode === "edit" || Boolean(submission.original_path || submission.originalPath);
+}
+
+function addEditPathCheck(result, submission) {
+  const originalPath = submission.original_path || submission.originalPath || "the original recipe file";
+  addValidationCheck(result.validation_report, result.errors, result.warnings, "pass", "slug", "edit_recipe_path", `Edit mode will update ${originalPath}; duplicate filename checks are skipped for the existing recipe.`);
+  finalizeValidationReport(result.validation_report);
+  result.ok = result.errors.length === 0;
 }
 
 async function addDuplicatePathCheck(result, env) {

--- a/functions/api/recipes/preview.js
+++ b/functions/api/recipes/preview.js
@@ -1,17 +1,22 @@
-import { buildRecipe } from "../../_shared/recipe.js";
+import { checkRecipeFileExists } from "../../_shared/github-validation.js";
+import { addValidationCheck, buildRecipe, finalizeValidationReport } from "../../_shared/recipe.js";
 import { json, methodNotAllowed, optionsResponse, readSubmission } from "../../_shared/http.js";
 
 export async function onRequestOptions() {
   return optionsResponse();
 }
 
-export async function onRequestPost({ request }) {
+export async function onRequestPost({ request, env }) {
   try {
     const submission = await readSubmission(request);
     const result = buildRecipe(submission, { verifyTurnstile: false });
 
+    if (result.recipe && result.recipe.path && result.recipe.slug) {
+      await addDuplicatePathCheck(result, env);
+    }
+
     if (!result.ok) {
-      return json({ ok: false, errors: result.errors, warnings: result.warnings }, 400);
+      return json({ ok: false, errors: result.errors, warnings: result.warnings, validation_report: result.validation_report }, 400);
     }
 
     return json(result);
@@ -22,4 +27,19 @@ export async function onRequestPost({ request }) {
 
 export async function onRequest() {
   return methodNotAllowed();
+}
+
+async function addDuplicatePathCheck(result, env) {
+  const duplicate = await checkRecipeFileExists(result.recipe, env);
+
+  if (duplicate.checked && duplicate.exists) {
+    addValidationCheck(result.validation_report, result.errors, result.warnings, "error", "slug", "duplicate_recipe_path", `A recipe already exists at ${duplicate.path}.`);
+  } else if (duplicate.checked) {
+    addValidationCheck(result.validation_report, result.errors, result.warnings, "pass", "slug", "duplicate_recipe_path_clear", `No recipe file exists yet at ${duplicate.path}.`);
+  } else {
+    addValidationCheck(result.validation_report, result.errors, result.warnings, "warning", "slug", "duplicate_recipe_path_unchecked", duplicate.error || "Could not check for a duplicate recipe filename.");
+  }
+
+  finalizeValidationReport(result.validation_report);
+  result.ok = result.errors.length === 0;
 }

--- a/functions/api/recipes/submit.js
+++ b/functions/api/recipes/submit.js
@@ -13,16 +13,16 @@ export async function onRequestPost({ request, env }) {
     const validation = buildRecipe(submission, { verifyTurnstile: true });
 
     if (!validation.ok) {
-      return json({ ok: false, errors: validation.errors, warnings: validation.warnings }, 400);
+      return json({ ok: false, errors: validation.errors, warnings: validation.warnings, validation_report: validation.validation_report }, 400);
     }
 
     const turnstile = await verifyTurnstile(submission.turnstileToken, request, env);
     if (!turnstile.ok) {
-      return json({ ok: false, errors: [turnstile.error || "Turnstile verification failed."], warnings: validation.warnings }, 403);
+      return json({ ok: false, errors: [turnstile.error || "Turnstile verification failed."], warnings: validation.warnings, validation_report: validation.validation_report }, 403);
     }
 
     const pr = await createRecipePullRequest(validation.recipe, validation.warnings, env);
-    return json({ ok: true, pullRequest: pr, warnings: validation.warnings }, 201);
+    return json({ ok: true, pullRequest: pr, warnings: validation.warnings, validation_report: validation.validation_report }, 201);
   } catch (error) {
     return json({ ok: false, error: error.message || "Unexpected error" }, 500);
   }

--- a/js/rendered-recipe-preview.js
+++ b/js/rendered-recipe-preview.js
@@ -25,7 +25,7 @@
 
       panel.hidden = false;
       renderRecipe(payload);
-      setFeedback('Checking preview…', [], []);
+      setFeedback('Checking preview…', null, [], []);
 
       try {
         var response = await window.fetch(endpoint, {
@@ -38,14 +38,14 @@
         if (currentRequestId !== requestId) return;
 
         if (!response.ok || !result.ok) {
-          setFeedback('Preview needs attention', result.errors || [result.error].filter(Boolean), result.warnings || []);
+          setFeedback('Preview needs attention', result.validation_report, result.errors || [result.error].filter(Boolean), result.warnings || []);
           return;
         }
 
-        setFeedback('Preview looks ready', [], result.warnings || []);
+        setFeedback('Preview looks ready', result.validation_report, [], result.warnings || []);
       } catch (error) {
         if (currentRequestId !== requestId) return;
-        setFeedback('Could not refresh preview validation', [error.message || 'Preview validation failed.'], []);
+        setFeedback('Could not refresh preview validation', null, [error.message || 'Preview validation failed.'], []);
       }
     }
 
@@ -54,7 +54,7 @@
       window.clearTimeout(timer);
       panel.hidden = false;
       card.innerHTML = '';
-      setFeedback('Start typing to see a rendered recipe preview.', [], []);
+      setFeedback('Start typing to see a rendered recipe preview.', null, [], []);
       schedule(0);
     }
 
@@ -171,14 +171,47 @@
       return section;
     }
 
-    function setFeedback(title, errors, warnings) {
+    function setFeedback(title, report, errors, warnings) {
       feedback.innerHTML = '';
       var heading = document.createElement('strong');
       heading.textContent = title;
       feedback.appendChild(heading);
 
+      if (report && report.summary) {
+        var summary = document.createElement('p');
+        summary.className = 'recipe-validation-summary';
+        summary.textContent = report.summary.errors + ' errors · ' + report.summary.warnings + ' warnings · ' + report.summary.passes + ' passed checks';
+        feedback.appendChild(summary);
+      }
+
+      if (report && report.checks && report.checks.length) {
+        appendValidationChecks(report.checks);
+        return;
+      }
+
       appendMessages('Errors', errors, 'recipe-preview-errors');
       appendMessages('Warnings', warnings, 'recipe-preview-warnings');
+    }
+
+    function appendValidationChecks(checks) {
+      var list = document.createElement('ul');
+      list.className = 'recipe-validation-checks';
+
+      checks.forEach(function (check) {
+        var item = document.createElement('li');
+        item.className = 'recipe-validation-check recipe-validation-check-' + check.status;
+        item.textContent = statusLabel(check.status) + ' ' + check.message;
+        list.appendChild(item);
+      });
+
+      feedback.appendChild(list);
+    }
+
+    function statusLabel(status) {
+      if (status === 'error') return 'Error:';
+      if (status === 'warning') return 'Warning:';
+      if (status === 'pass') return 'Pass:';
+      return 'Check:';
     }
 
     function appendMessages(title, messages, className) {


### PR DESCRIPTION
Adds structured recipe validation reports for preview, submit, and edit flows.

Summary:
- Returns a machine-readable validation_report with checks, statuses, and summary counts.
- Shows validation checks in the live rendered preview.
- Keeps existing errors and warnings fields for compatibility.
- Checks duplicate recipe path during preview and before creating a submission branch.

Testing: not run locally in this environment.

Related: #71