### PR TITLE
Warn about possible duplicate recipes

### DIFF
--- a/docs/recipe-duplicate-checks.md
+++ b/docs/recipe-duplicate-checks.md
@@ -1,0 +1,23 @@
+# Recipe duplicate checks
+
+Recipe submissions use two duplicate checks before creating a review pull request.
+
+## Exact filename check
+
+The submission flow checks whether the generated recipe file already exists in `_recipes` on the base branch. This is treated as a blocking error because creating the PR would overwrite an existing recipe path.
+
+## Similar recipe warning
+
+The submission flow also compares the new recipe title and generated filename against existing recipe filenames in `_recipes`. This is a warning, not a blocker. Family members can still submit when the recipe is intentionally different.
+
+The warning looks for:
+
+- Matching normalized titles derived from recipe filenames.
+- Matching normalized filename slugs.
+- Similar titles based on lightweight text and token similarity.
+
+## Limitations
+
+This check intentionally avoids full recipe scraping or expensive content comparison. It compares the new title/slug against existing filenames, so it may miss duplicates when an old filename does not closely match the actual recipe title. It may also warn on recipes that are related but intentionally different, such as two versions of the same cake or sauce.
+
+Reviewers should treat similarity warnings as a prompt to compare recipes, not as a final decision.

--- a/functions/_shared/github-validation.js
+++ b/functions/_shared/github-validation.js
@@ -1,4 +1,6 @@
 const DEFAULT_BASE_BRANCH = "main";
+const RECIPE_DIR = "_recipes";
+const MAX_SIMILAR_MATCHES = 5;
 
 export async function checkRecipeFileExists(recipe, env) {
   const owner = env.GITHUB_OWNER || "cjthedj97";
@@ -35,6 +37,165 @@ export async function checkRecipeFileExists(recipe, env) {
     path: recipe.path,
     branch: base
   };
+}
+
+export async function findSimilarRecipeMatches(recipe, env) {
+  const owner = env.GITHUB_OWNER || "cjthedj97";
+  const repo = env.GITHUB_REPO || "chowdown";
+  const base = env.GITHUB_BASE_BRANCH || DEFAULT_BASE_BRANCH;
+  const token = env.GITHUB_TOKEN;
+  const path = `/repos/${owner}/${repo}/contents/${RECIPE_DIR}?ref=${encodeURIComponent(base)}`;
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: buildHeaders(token)
+  });
+
+  if (!response.ok) {
+    return {
+      checked: false,
+      branch: base,
+      matches: [],
+      error: `GitHub similar recipe check failed with status ${response.status}.`
+    };
+  }
+
+  const files = await response.json();
+  if (!Array.isArray(files)) {
+    return {
+      checked: false,
+      branch: base,
+      matches: [],
+      error: "GitHub similar recipe check returned an unexpected response."
+    };
+  }
+
+  const incoming = recipeFingerprint(recipe.title || titleFromPath(recipe.path), recipe.path);
+  const matches = files
+    .filter((file) => file && file.type === "file" && file.path && file.path.endsWith(".md"))
+    .filter((file) => file.path !== recipe.path)
+    .map((file) => {
+      const title = titleFromPath(file.path);
+      const existing = recipeFingerprint(title, file.path);
+      const titleScore = similarity(incoming.normalizedTitle, existing.normalizedTitle);
+      const slugScore = similarity(incoming.normalizedSlug, existing.normalizedSlug);
+      const tokenScore = tokenSimilarity(incoming.tokens, existing.tokens);
+      const score = Math.max(titleScore, slugScore, tokenScore);
+      const kind = duplicateKind(incoming, existing, score);
+
+      return {
+        title,
+        path: file.path,
+        kind,
+        score
+      };
+    })
+    .filter((match) => match.kind)
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
+    .slice(0, MAX_SIMILAR_MATCHES);
+
+  return {
+    checked: true,
+    branch: base,
+    matches
+  };
+}
+
+function duplicateKind(incoming, existing, score) {
+  if (incoming.normalizedTitle && incoming.normalizedTitle === existing.normalizedTitle) return "matching title";
+  if (incoming.normalizedSlug && incoming.normalizedSlug === existing.normalizedSlug) return "matching filename";
+  if (incoming.tokens.length >= 2 && existing.tokens.length >= 2 && score >= 0.82) return "similar title";
+  return "";
+}
+
+function recipeFingerprint(title, path) {
+  const normalizedTitle = normalizeTitle(title);
+  const normalizedSlug = normalizeTitle(slugFromPath(path));
+  const tokens = tokenize(`${normalizedTitle} ${normalizedSlug}`);
+
+  return {
+    normalizedTitle,
+    normalizedSlug,
+    tokens
+  };
+}
+
+function titleFromPath(path) {
+  return slugFromPath(path)
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+    .trim();
+}
+
+function slugFromPath(path) {
+  return String(path || "")
+    .split("/")
+    .pop()
+    .replace(/\.md$/i, "")
+    .trim();
+}
+
+function normalizeTitle(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\b(the|a|an|and|or|with|of|for|to)\b/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenize(value) {
+  const seen = new Set();
+  return normalizeTitle(value)
+    .split(" ")
+    .filter((token) => token.length > 1)
+    .filter((token) => {
+      if (seen.has(token)) return false;
+      seen.add(token);
+      return true;
+    });
+}
+
+function similarity(left, right) {
+  if (!left || !right) return 0;
+  if (left === right) return 1;
+
+  const distance = levenshtein(left, right);
+  return 1 - (distance / Math.max(left.length, right.length));
+}
+
+function tokenSimilarity(leftTokens, rightTokens) {
+  if (!leftTokens.length || !rightTokens.length) return 0;
+
+  const left = new Set(leftTokens);
+  const right = new Set(rightTokens);
+  let intersection = 0;
+
+  left.forEach((token) => {
+    if (right.has(token)) intersection += 1;
+  });
+
+  return intersection / new Set([...left, ...right]).size;
+}
+
+function levenshtein(left, right) {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+
+  for (let i = 0; i < left.length; i += 1) {
+    let current = [i + 1];
+
+    for (let j = 0; j < right.length; j += 1) {
+      const insert = current[j] + 1;
+      const remove = previous[j + 1] + 1;
+      const replace = previous[j] + (left[i] === right[j] ? 0 : 1);
+      current.push(Math.min(insert, remove, replace));
+    }
+
+    for (let j = 0; j < current.length; j += 1) {
+      previous[j] = current[j];
+    }
+  }
+
+  return previous[right.length];
 }
 
 function buildHeaders(token) {

--- a/functions/_shared/github.js
+++ b/functions/_shared/github.js
@@ -49,7 +49,8 @@ export async function createRecipePullRequest(recipe, warnings, env) {
     "✅ Required fields validated before commit",
     "✅ Spam-check field checked before GitHub write",
     "✅ Turnstile checked before GitHub write",
-    "✅ Duplicate filename checked against the base branch"
+    "✅ Duplicate filename checked against the base branch",
+    "✅ Similar recipe title warnings checked against the base branch"
   ];
 
   if (warnings && warnings.length) {
@@ -69,7 +70,7 @@ export async function createRecipePullRequest(recipe, warnings, env) {
     "",
     "This PR was opened by the recipe submission Pages Function. Review the generated Markdown and Cloudflare Pages preview before merging.",
     "",
-    "Related roadmap issues: #69, #71, #81, #83"
+    "Related roadmap issues: #69, #71, #81, #83, #87"
   ].join("\n");
 
   const pr = await github(`${repoPath}/pulls`, {

--- a/functions/api/recipes/preview.js
+++ b/functions/api/recipes/preview.js
@@ -1,4 +1,4 @@
-import { checkRecipeFileExists } from "../../_shared/github-validation.js";
+import { checkRecipeFileExists, findSimilarRecipeMatches } from "../../_shared/github-validation.js";
 import { addValidationCheck, buildRecipe, finalizeValidationReport } from "../../_shared/recipe.js";
 import { json, methodNotAllowed, optionsResponse, readSubmission } from "../../_shared/http.js";
 
@@ -15,6 +15,7 @@ export async function onRequestPost({ request, env }) {
       addEditPathCheck(result, submission);
     } else if (result.recipe && result.recipe.path && result.recipe.slug) {
       await addDuplicatePathCheck(result, env);
+      await addSimilarRecipeChecks(result, env);
     }
 
     if (!result.ok) {
@@ -51,6 +52,24 @@ async function addDuplicatePathCheck(result, env) {
     addValidationCheck(result.validation_report, result.errors, result.warnings, "pass", "slug", "duplicate_recipe_path_clear", `No recipe file exists yet at ${duplicate.path}.`);
   } else {
     addValidationCheck(result.validation_report, result.errors, result.warnings, "warning", "slug", "duplicate_recipe_path_unchecked", duplicate.error || "Could not check for a duplicate recipe filename.");
+  }
+
+  finalizeValidationReport(result.validation_report);
+  result.ok = result.errors.length === 0;
+}
+
+async function addSimilarRecipeChecks(result, env) {
+  const similar = await findSimilarRecipeMatches(result.recipe, env);
+
+  if (!similar.checked) {
+    addValidationCheck(result.validation_report, result.errors, result.warnings, "warning", "title", "similar_recipe_unchecked", similar.error || "Could not check for similar recipe titles.");
+  } else if (similar.matches.length) {
+    const matches = similar.matches
+      .map((match) => `${match.title} (${match.path})`)
+      .join("; ");
+    addValidationCheck(result.validation_report, result.errors, result.warnings, "warning", "title", "similar_recipe_found", `Possible duplicate recipe found: ${matches}. You can still submit if this is intentionally different.`);
+  } else {
+    addValidationCheck(result.validation_report, result.errors, result.warnings, "pass", "title", "similar_recipe_clear", "No similar recipe titles were found.");
   }
 
   finalizeValidationReport(result.validation_report);

--- a/functions/api/recipes/submit.js
+++ b/functions/api/recipes/submit.js
@@ -1,5 +1,6 @@
 import { createRecipePullRequest } from "../../_shared/github.js";
-import { buildRecipe } from "../../_shared/recipe.js";
+import { findSimilarRecipeMatches } from "../../_shared/github-validation.js";
+import { addValidationCheck, buildRecipe, finalizeValidationReport } from "../../_shared/recipe.js";
 import { verifyTurnstile } from "../../_shared/turnstile.js";
 import { json, methodNotAllowed, optionsResponse, readSubmission } from "../../_shared/http.js";
 
@@ -21,6 +22,8 @@ export async function onRequestPost({ request, env }) {
       return json({ ok: false, errors: [turnstile.error || "Turnstile verification failed."], warnings: validation.warnings, validation_report: validation.validation_report }, 403);
     }
 
+    await addSimilarRecipeChecks(validation, env);
+
     const pr = await createRecipePullRequest(validation.recipe, validation.warnings, env);
     return json({ ok: true, pullRequest: pr, warnings: validation.warnings, validation_report: validation.validation_report }, 201);
   } catch (error) {
@@ -30,4 +33,22 @@ export async function onRequestPost({ request, env }) {
 
 export async function onRequest() {
   return methodNotAllowed();
+}
+
+async function addSimilarRecipeChecks(validation, env) {
+  const similar = await findSimilarRecipeMatches(validation.recipe, env);
+
+  if (!similar.checked) {
+    addValidationCheck(validation.validation_report, validation.errors, validation.warnings, "warning", "title", "similar_recipe_unchecked", similar.error || "Could not check for similar recipe titles.");
+  } else if (similar.matches.length) {
+    const matches = similar.matches
+      .map((match) => `${match.title} (${match.path})`)
+      .join("; ");
+    addValidationCheck(validation.validation_report, validation.errors, validation.warnings, "warning", "title", "similar_recipe_found", `Possible duplicate recipe found: ${matches}. You can still submit if this is intentionally different.`);
+  } else {
+    addValidationCheck(validation.validation_report, validation.errors, validation.warnings, "pass", "title", "similar_recipe_clear", "No similar recipe titles were found.");
+  }
+
+  finalizeValidationReport(validation.validation_report);
+  validation.ok = validation.errors.length === 0;
 }


### PR DESCRIPTION
Adds non-blocking duplicate warnings for recipe submissions.

What changed:
- Keeps the existing exact generated filename check.
- Adds similar title and filename warnings against existing `_recipes` files.
- Shows possible duplicates in preview validation.
- Carries those warnings into submitted recipe PRs.
- Documents the lightweight matching approach and limitations.

The warning does not block intentional variants or family-specific versions.

Closes #87